### PR TITLE
Implement the retry of connections

### DIFF
--- a/servers_response.go
+++ b/servers_response.go
@@ -13,19 +13,19 @@ import (
 	Implements servers response of SOCKS5 for non Linux systems
 */
 func server_response(local_conn net.Conn, remote_address string) {
-	load_balancer := get_load_balancer()
+	load_balancer, i := get_load_balancer()
 
 	local_tcpaddr, _ := net.ResolveTCPAddr("tcp4", load_balancer.address)
 	remote_tcpaddr, _ := net.ResolveTCPAddr("tcp4", remote_address)
 	remote_conn, err := net.DialTCP("tcp4", local_tcpaddr, remote_tcpaddr)
 
 	if err != nil {
-		log.Println("[WARN]", remote_address, "->", load_balancer.address, fmt.Sprintf("{%s}", err))
+		log.Println("[WARN]", remote_address, "->", load_balancer.address, fmt.Sprintf("{%s}", err), "LB:", i)
 		local_conn.Write([]byte{5, NETWORK_UNREACHABLE, 0, 1, 0, 0, 0, 0, 0, 0})
 		local_conn.Close()
 		return
 	}
-	log.Println("[DEBUG]", remote_address, "->", load_balancer.address)
+	log.Println("[DEBUG]", remote_address, "->", load_balancer.address, "LB:", i)
 	local_conn.Write([]byte{5, SUCCESS, 0, 1, 0, 0, 0, 0, 0, 0})
 	pipe_connections(local_conn, remote_conn)
 }


### PR DESCRIPTION
When using multiple proxy upstreams, when one connection fails becuase the proxy is not available, then try the next until check all available.

With this new behaviour, you never receive an error if almost one proxy is reachable. Useful in environments when multiple non-reliable proxies are used.